### PR TITLE
Update index.md of EGI 2024 to include tags and subsites related to ESG

### DIFF
--- a/content/news/2024-10-10-egi2024/index.md
+++ b/content/news/2024-10-10-egi2024/index.md
@@ -3,7 +3,11 @@ title: 'Freiburg Galaxy team at the EGI 2024'
 date: "2024-10-10"
 tease: "Members from the Freiburg Galaxy team traveled to Lecce, Italy to participate and present the EuroScienceGateway (ESG) project at the EGI2024 meeting from 1st-3rd October."
 hide_tease: false
-subsites: [all-eu]
+tags: [esg]
+supporters:
+- eurosciencegateway
+- unifreiburg
+subsites: [all-eu, global, esg]
 main_subsite: eu
 ---
 


### PR DESCRIPTION
I was asked to write a news post for the EGI 2024 because we thought it was a missing blog post [here](https://github.com/usegalaxy-eu/issues/issues/645#issuecomment-2630374273). However, I found this blog post later, and I noticed that it lacks the `esg` tag and `esg` subsites as well as the supporters.